### PR TITLE
🔥 Remove `Glucose Direct`

### DIFF
--- a/docs/Getting-Started/cgm.md
+++ b/docs/Getting-Started/cgm.md
@@ -8,14 +8,13 @@ CGM selection includes the following:
 * [Dexcom G7/Dexcom ONE+](#dexcom-g7-and-dexcom-one)
 * [Glucose Simulator](#glucose-simulator)
 * [Libre Transmitter](#libre-transmitter)
-* [Glucose Direct](#glucose-direct)
 * [Medtronic Enlite](#medtronic-enlite)
 
 ## Nightscout
 While using Nightscout as a CGM is an option, it should be avoided if possible because it does not keep Trio running in the background like other CGM options.
 
 ## xDrip (xDrip4iOS)
-To use xDrip4iOS as a cgm source, you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use Shuggah or a version distributed by someone else's TestFlight. Please see the following for instructions on how to build xDrip4iOS yourself: [link](../operate/build.md#xdrip4ios-or-glucose-direct-as-cgm-source)
+To use xDrip4iOS as a cgm source, you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use Shuggah or a version distributed by someone else's TestFlight. Please see the following for instructions on how to build xDrip4iOS yourself: [link](../operate/build.md#xdrip4ios-as-cgm-source)
 
 However, if you are using Dexcom G6 or ONE with xDrip4iOS, you can choose the Dexcom G6 option in Trio rather than xDrip4iOS, and Trio will intercept the glucose readings even if you're using Shuggah or someone else's TestFlight of xDrip4iOS.
 
@@ -29,10 +28,7 @@ As long as the Dexcom G7 or ONE+ app is installed on the same phone, Trio can in
 This option should ***only*** be used when learning how to interact with the app. It should not be used to learn how the algorithm will respond, nor should it ever be used on a living being.
 
 ## Libre Transmitter
-This option can be used to pair a compatible Libre cgm directly to Trio without going through a separate app like xDrip4iOS or Glucose Direct.
-
-## Glucose Direct
-Until the providers of Glucose Direct add a Trio App Group to Glucose Direct, you cannot use this app with Trio. If that happens, then you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use a version distributed by someone else's TestFlight.
+This option can be used to pair a compatible Libre cgm directly to Trio without going through a separate app like xDrip4iOS.
 
 ## Medtronic Enlite
 The Minimed Enlite CGM, available with the Medtronic 522/722, 523/723, and 554/754, wirelessly sends glucose readings to the pump. Trio can read the Medtronic CGM data directly from the pump using a RileyLink-compatible device.

--- a/docs/operate/build.md
+++ b/docs/operate/build.md
@@ -179,7 +179,6 @@ The choices are:
 
 1. `Build Loop Follow`
 2. `Build xDrip4iOS`
-3. `Build Glucose Direct`
 4. `Return to Menu`
 
 ### Run Maintenance Utilities
@@ -207,19 +206,15 @@ If you need it, you are most likely to get help in one of these groups:
 * [Facebook group: Trio](https://www.facebook.com/groups/1351938092206709)
 * Facebook groups like [Loop and Learn](https://www.facebook.com/groups/LOOPandLEARN) and [Looped](https://www.facebook.com/groups/1782449781971680) primarily focus on Loop but offer a wide variety of support surrounding all types of DIY Looping.
 
-### xDrip4iOS or Glucose Direct as CGM Source
+### xDrip4iOS as CGM Source
 
 !!! important
     
-    LibreTransmitter is provided as part of Trio. Neither xDrip4iOS nor Glucose Direct are required to interact with your compatible Libre sensor using Trio.
-
-!!! important
-    
-    Until the providers of Glucose Direct add a Trio App Group to their app, you cannot use this app with Trio.
+    LibreTransmitter is provided as part of Trio. xDrip4iOS is **not** required to interact with your compatible Libre sensor using Trio.
 
 If you want to use xDrip4iOS as a CGM source via “shared app group,” you must also build that app from a source with the same developer ID used for building Trio. Scripts are available for these apps as well. All scripts follow the same download and build pattern and configure automatic signing files for you.
 
-The download is placed in your `Downloads` folder in a directory called `BuildxDrip4iOS` or `BuildGlucoseDirect`, respectively. The downloaded clone is found in a folder with the branch name, date, and time encoded.
+The download is placed in your `Downloads` folder in a directory called `BuildxDrip4iOS`, respectively. The downloaded clone is found in a folder with the branch name, date, and time encoded.
 
 These can be accessed using the [**TrioBuildSelectScript**](#build-trio-with-script) menu options mentioned above. Or you can run each script individually.
 
@@ -232,17 +227,6 @@ These can be accessed using the [**TrioBuildSelectScript**](#build-trio-with-scr
 ```
 /bin/bash -c "$(curl -fsSL \
   https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildxDrip4iOS.sh)"
-```
-
-### Glucose Direct
-
-!!! important
-    
-    Until the providers of Glucose Direct add a `Trio App Group` to their app, you cannot use this app with Trio.
-
-```
-/bin/bash -c "$(curl -fsSL \
-  https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildGlucoseDirect.sh)"
 ```
 
 ### Alternative Branch for Trio

--- a/docs/settings/devices/cgm.md
+++ b/docs/settings/devices/cgm.md
@@ -9,14 +9,13 @@ CGM selection includes the following:
 * Dexcom G7/ONE+
 * Glucose Simulator
 * Libre Transmitter
-* Glucose Direct
 * Medtronic Enlite
 
 ## Nightscout
 While using Nightscout as a CGM is an option, it should be avoided if possible because it will not keep Trio running in the background like other CGM options. You will have to open Trio manually to make it run loop cycles.
 
 ## xDrip (xDrip4iOS)
-To use xDrip4iOS as a CGM source, you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use Shuggah or a version distributed by someone else's TestFlight. Please see the following for instructions on how to build xDrip4iOS yourself: [link](../../operate/build.md#xdrip4ios-or-glucose-direct-as-cgm-source)
+To use xDrip4iOS as a CGM source, you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use Shuggah or a version distributed by someone else's TestFlight. Please see the following for instructions on how to build xDrip4iOS yourself: [link](../../operate/build.md#xdrip4ios-as-cgm-source)
 
 However, if you are using Dexcom G6 or ONE with xDrip4iOS, you can choose the Dexcom G6 option in Trio rather than xDrip4iOS, and Trio will intercept the glucose readings even if you're using Shuggah or someone else's TestFlight of xDrip4iOS.
 
@@ -34,7 +33,7 @@ The Glucose Simulator adds artificial CGM readings to the screen so you can see 
     ***The Glucose Simulator should never be used in conjunction with a live pump connected to a person (or animal).***
 
 ## Libre Transmitter
-This option pairs a compatible Libre CGM directly with Trio without using a separate app like xDrip4iOS or Glucose Direct.
+This option pairs a compatible Libre CGM directly with Trio without using a separate app like xDrip4iOS.
 
 ### Supported Sensors
 * US Libre 1 10-day sensors *via Transmitters*
@@ -49,8 +48,5 @@ This option pairs a compatible Libre CGM directly with Trio without using a sepa
 * Libre H sensors
 * Libre 3
   
-## Glucose Direct
-Until the providers of Glucose Direct add a Trio App Group to Glucose Direct, you cannot use this app with Trio. If that happens, then you must build it yourself with the same Apple Developer account you used to build your Trio app. You cannot use a version distributed by someone else's TestFlight.
-
 ## Medtronic Enlite
 The Minimed Enlite CGM, available with the Medtronic 522/722, 523/723, and 554/754, wirelessly sends glucose readings to the pump. Trio can read the Medtronic CGM data directly from the pump using a RileyLink-compatible device.


### PR DESCRIPTION
This PR removes _Glucose Direct_ from Trio-Docs.

See: https://loopandlearneditors.slack.com/archives/C070ZKLKW82/p1729350863008289

⚠️ **IMPORTANT**: It requires PR #83 to be merged beforehand.