### PR TITLE
👷 Add a Workflow to check for PR Dependencies

### DIFF
--- a/.github/workflows/check_blocking_prs_and_issues.yml
+++ b/.github/workflows/check_blocking_prs_and_issues.yml
@@ -1,0 +1,23 @@
+name: Check for Blocked PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+    issues:
+      types:
+        - opened
+        - edited
+        - deleted
+        - transferred
+        - closed
+        - reopened
+
+jobs:
+  blocking_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Levi-Lesches/blocking-issues@v2


### PR DESCRIPTION
See: https://github.com/gregsdennis/dependencies-action


## Dpulls GitHub App

Depends on #5  
depends on #7

`Depends on` is **[dpulls](https://www.dpulls.com/) syntax** to denote a dependency.  
`blocking-issues` does not recognize this syntax and ignores it.

> This PR depends on issue 5.
> **`dpulls`** ignores this **issue** dependencies but only focuses on PR dependencies.
  > **`blocking-issues`** accepts PR dependencies **and issues** dependencies

> This PR depends on PR 7. Both `dpulls` and blocking-issues` handle PR dependencies.

## blocking-issue GitHub Action

`Blocked by` is **[blocking-issues](https://github.com/marketplace/actions/blocking-issues) syntax** to denote a dependency. It accepts PR **and issue** dependencies.  
`dpulls` does **not** recognize this syntax and ignores it.

Blocked by #5, #7


ℹ️ Source: https://github.com/orgs/community/discussions/4477#discussioncomment-1039627
.